### PR TITLE
Added a MonadUnliftIO instance for ActionT

### DIFF
--- a/src/Control/Concurrent/Actor.hs
+++ b/src/Control/Concurrent/Actor.hs
@@ -46,6 +46,7 @@ module Control.Concurrent.Actor
 import Control.Concurrent
     ( forkFinally, myThreadId, throwTo, ThreadId )
 import Control.Monad.IO.Class ( MonadIO(..) )
+import Control.Monad.IO.Unlift ( MonadUnliftIO(..) )
 import Control.Monad.Trans ( MonadTrans(..) )
 import Control.Monad.Reader
     ( MonadReader(local, ask), ReaderT(ReaderT) )
@@ -77,6 +78,7 @@ deriving via ReaderT (ActorContext message) m instance MonadError e m => MonadEr
 deriving via ReaderT (ActorContext message) m instance MonadWriter w m => MonadWriter w (ActionT message m)
 deriving via ReaderT (ActorContext message) m instance MonadState s m => MonadState s (ActionT message m)
 deriving via ReaderT (ActorContext message) m instance MonadCont m => MonadCont (ActionT message m)
+deriving via ReaderT (ActorContext message) m instance MonadUnliftIO m => MonadUnliftIO (ActionT message m)
 
 instance MonadReader r m => MonadReader r (ActionT message m) where
   ask = ActionT (const ask)

--- a/stm-actor.cabal
+++ b/stm-actor.cabal
@@ -33,7 +33,8 @@ library
                        stm >=2.1,
                        stm-queue >=0.1,
                        mtl >=1.0,
-                       transformers >=0.0
+                       unliftio-core >= 0.2,
+                       transformers >=0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
As pointed out in https://www.reddit.com/r/haskell/comments/iwu6y0/ann_stmactor_stmqueue/g6q3ntb?utm_source=share&utm_medium=web2x&context=3, it makes sense to have a MonadUnliftIO instance for ActionT, so that we can use the `unliftio` package for various contravariant concurrency and error handling primitives abstracted over all MonadUnliftIO things. Thankfully, this package is factored out in a nice way that allows us to only depend on the much smaller`unliftio-core` package.