### PR TITLE
Remove restriction on base

### DIFF
--- a/stm-actor.cabal
+++ b/stm-actor.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                stm-actor
-version:             0.3.1.0
+version:             0.3.1.1
 license:             MIT
 license-file:        LICENSE
 synopsis:            A simplistic actor model based on STM
@@ -18,7 +18,7 @@ source-repository head
 
 library
   exposed-modules:     Control.Concurrent.Actor
-  build-depends:       base >=4.12 && <4.18,
+  build-depends:       base >=4.12,
                        stm >=2.1,
                        stm-queue >=0.2,
                        mtl >=1.0,


### PR DESCRIPTION
The restriction on base < 4.18 prevents compiling with GHC 9.6.6 and higher. I think it is safe to drop that restriction entirely.

Could you please bump this version to hackage?